### PR TITLE
Add various exit support signals

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/djieff/vspleeter',
-    version='1.0.1',
+    version='1.0.2',
     zip_safe=False,
 )

--- a/vspleeter/__main__.py
+++ b/vspleeter/__main__.py
@@ -2,6 +2,7 @@
 """
 import glob
 import os
+import signal
 import sys
 import subprocess
 
@@ -17,6 +18,9 @@ OUTPUT_PATH_SUFFIX = "{rootOutputDir}/{basename}_spleeted/{binaryType}/{stemNum}
 def main():
     """main function
     """
+    # Adds Ctrl+C support to kill app
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
     QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
 
     app = QApplication(sys.argv)
@@ -179,6 +183,7 @@ def main():
     mw.inputFilePushButton.clicked.connect(browseForInputFile)
     mw.outputDirPushButton.clicked.connect(browseForOutputDir)
     mw.processPushButton.clicked.connect(processBatchElements)
+    mw.actionexit.triggered.connect(app.quit)
     mw.show()
     sys.exit(app.exec_())
 

--- a/vspleeter/vspleeter_mainWindow.ui
+++ b/vspleeter/vspleeter_mainWindow.ui
@@ -197,6 +197,7 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <addaction name="actionexit"/>
    </widget>
    <addaction name="menu_File"/>
   </widget>
@@ -212,6 +213,11 @@
     <bool>false</bool>
    </attribute>
   </widget>
+  <action name="actionexit">
+   <property name="text">
+    <string>exit</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
Purpose of PR:
I was notified that the File|Exit didn't work. This pr handles this, plus adding keyboard interrupt support.

Code change:
Added the Exit action menu in the vspleeter_mainWindow.ui
Add signal handling for keyboard interupt, and exit actionmenu

What could break:
Tested all the new ways to exit, and it was clean
I cannot test on mac os, or windows, so there could be unknown behaviors here
